### PR TITLE
MOBILE-817 gulp: Added missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bower": "^1.3.3",
     "gulp-clip-empty-files": "^0.1.1",
     "gulp-concat-util": "^0.5.2",
+    "gulp-insert": "^0.4.0",
     "gulp-remove-empty-lines": "0.0.2",
     "gulp-strip-comments": "^1.0.1",
     "gulp-tap": "^0.1.3",


### PR DESCRIPTION
The gulp-insert dependency was missing in package.json.