### PR TITLE
Fix login via a browser window with a custom URL scheme

### DIFF
--- a/www/core/components/login/main.js
+++ b/www/core/components/login/main.js
@@ -94,7 +94,7 @@ angular.module('mm.core.login', [])
 })
 
 .run(function($log, $state, $mmUtil, $translate, $mmSitesManager, $rootScope, $mmSite, $mmURLDelegate, $ionicHistory,
-                $mmEvents, $mmLoginHelper, mmCoreEventSessionExpired, $mmApp) {
+                $mmEvents, $mmLoginHelper, mmCoreEventSessionExpired, $mmApp, mmCoreConfigConstants) {
 
     $log = $log.getInstance('mmLogin');
 
@@ -178,7 +178,7 @@ angular.module('mm.core.login', [])
 
     // Function to handle URL received by Custom URL Scheme. If it's a SSO login, perform authentication.
     function appLaunchedByURL(url) {
-        var ssoScheme = 'moodlemobile://token=';
+        var ssoScheme = mmCoreConfigConstants.customurlscheme + '://token=';
         if (url.indexOf(ssoScheme) == -1) {
             return false;
         }


### PR DESCRIPTION
Users can't to log in when using a custom URL scheme because the URL is checked against the string "moodlemobile://token=", instead of using the setting defined in www/config.json.