### PR TITLE
Updating gulp-sass and consequently node-sass that is running errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "mm2: An Ionic project",
   "dependencies": {
     "gulp": "^3.5.6",
-    "gulp-sass": "^1.3.3",
+    "gulp-sass": "^2.3.2",
     "gulp-concat": "^2.2.0",
     "gulp-minify-css": "^0.3.0",
     "gulp-rename": "^1.2.0"
@@ -75,7 +75,15 @@
     }
   ],
   "cordovaPlatforms": [
-    "ios",
-    "android"
+    {
+      "platform": "ios",
+      "version": "3.9.1",
+      "locator": "ios@3.9.1"
+    },
+    {
+      "platform": "android",
+      "version": "4.1.1",
+      "locator": "android@4.1.1"
+    }
   ]
 }


### PR DESCRIPTION
In the newer version of nodejs the library of node-sass is no longer available, so I update the package with a newer version of gulp-sass, The android and ios implementation is also instantiated.