### PR TITLE
MOBILE-1875 core: Run gulp tasks with ionic serve

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -356,6 +356,8 @@ var remoteAddonPaths = {
 
 gulp.task('default', ['build', 'sass', 'lang', 'config']);
 
+gulp.task('serve:before', ['default', 'watch']);
+
 gulp.task('sass-build', function(done) {
   gulp.src(paths.sass.core)
     .pipe(concat('mm.bundle.scss'))

--- a/ionic.project
+++ b/ionic.project
@@ -9,7 +9,9 @@
     "config"
   ],
   "watchPatterns": [
-    "www/**/*",
+    "www/**/*.html",
+    "www/build/**/*",
+    "www/index.html",
     "!www/lib/**/*"
   ]
 }


### PR DESCRIPTION
This issue solves the issue where the gulp default and watch task are not executed on ionic-cli v2, which is installed by default when running `npm install -g ionic`. It also solves an issue where livereload reloads the page multiple times since both the files that are built by the gulp build task and the built files are watched by Ionic.