### PR TITLE
MOBILE-1728 UX: Swipe to open side menu on all pages

### DIFF
--- a/www/core/components/sidemenu/controllers/menu.js
+++ b/www/core/components/sidemenu/controllers/menu.js
@@ -67,4 +67,41 @@ angular.module('mm.core.sidemenu')
             updateSiteObserver.off();
         }
     });
+
+    /**
+     * Get the button element for opening the side menu.
+     *
+     * There are always two menu buttons in the DOM. One is cached, while the other is active.
+     * When moving to another page the cached button will become staged and then active, while
+     * the active button will become cached.
+     *
+     * @module mm.addons.messages
+     * @ngdoc method
+     * @param  {String} navBarState        The value of the nav-bar attribute that it should use. Can be 'active', 'cached', 'stage'.
+     * @return {angular.element}           The button element, or null if not found.
+     */
+    function getSideMenuButton(navBarState) {
+        var navBarBlock = document.querySelector('.nav-bar-block[nav-bar="' + navBarState + '"]');
+        if (navBarBlock) {
+            return angular.element(navBarBlock.querySelector('#mm-side-menu-btn-menu'));
+        } else {
+            return null;
+        }
+    }
+
+    $scope.$on('$ionicView.beforeEnter', function (e, data) {
+        // During the beforeEnter state the nav-bar is in the 'stage' state, about to become 'active'.
+        var menuButton = getSideMenuButton('stage');
+        if (data.enableBack && menuButton && !menuButton.hasClass('hide')) {
+            menuButton.addClass('hide');
+        }
+    });
+
+    $scope.$on('$ionicView.afterEnter', function (e, data) {
+        // During the afterEnter state the nav-bar is already in the 'active' state.
+        var menuButton = getSideMenuButton('active');
+        if (!data.enableBack && menuButton && menuButton.hasClass('hide')) {
+            menuButton.removeClass('hide');
+        }
+    });
 });

--- a/www/core/components/sidemenu/templates/menu.html
+++ b/www/core/components/sidemenu/templates/menu.html
@@ -1,4 +1,4 @@
-<ion-side-menus enable-menu-with-back-views="false">
+<ion-side-menus enable-menu-with-back-views="true">
 
     <ion-side-menu-content>
 
@@ -6,7 +6,7 @@
             <ion-nav-back-button>
             </ion-nav-back-button>
             <ion-nav-buttons side="left">
-                <button menu-toggle="left" class="button button-icon icon ion-navicon" aria-label="{{ 'mm.sidemenu.togglemenu' | translate }}"></button>
+                <button id="mm-side-menu-btn-menu" menu-toggle="left" class="button button-icon icon ion-navicon" aria-label="{{ 'mm.sidemenu.togglemenu' | translate }}"></button>
             </ion-nav-buttons>
         </ion-nav-bar>
 


### PR DESCRIPTION
Testing instructions:
1. Make sure that the menu button and back arrow work as they used to.
2. Open any child page.
3. Swipe with your finger to the right, and the side menu should open.