### PR TITLE
MOBILE-1786 messages: Add unread message count in discussions

### DIFF
--- a/www/addons/messages/controllers/discussion.js
+++ b/www/addons/messages/controllers/discussion.js
@@ -216,11 +216,28 @@ angular.module('mm.addons.messages')
 
             // Notify that there can be a new message.
             notifyNewMessage();
+            markUnreadMessages();
         }).finally(function() {
             fetching = false;
         });
     }
 
+    function markUnreadMessages() {
+        console.log("AFTER HAVING FETCHED ALL");
+        console.log($scope.messages);
+        angular.forEach($scope.messages, function(message){
+            console.log(message.id);
+            // iF the message is unread, push it to the unreadMessages array.
+            if(message.read == 0 && message.useridto != userId) {
+                console.log("Found an unread message. Updating");
+                $mmaMessages.markMessageRead(message.id).then(function() {
+                    console.log('MARKING MESSAGE AS READ');
+                    message.read = 1;
+                    console.log(message);
+                });
+            }
+        });
+    }
     // Set a polling to get new messages every certain time.
     function setPolling() {
         if (polling) {

--- a/www/addons/messages/controllers/discussion.js
+++ b/www/addons/messages/controllers/discussion.js
@@ -216,24 +216,19 @@ angular.module('mm.addons.messages')
 
             // Notify that there can be a new message.
             notifyNewMessage();
-            markUnreadMessages();
+            markMessagesAsRead();
         }).finally(function() {
             fetching = false;
         });
     }
 
-    function markUnreadMessages() {
-        console.log("AFTER HAVING FETCHED ALL");
-        console.log($scope.messages);
+    // Mark messages as read.
+    function markMessagesAsRead() {
         angular.forEach($scope.messages, function(message){
-            console.log(message.id);
-            // iF the message is unread, push it to the unreadMessages array.
-            if(message.read == 0 && message.useridto != userId) {
-                console.log("Found an unread message. Updating");
+            // If the message is unread, call $mmaMessages.markMessageRead.
+            if (message.read == 0 && message.useridto != userId) {
                 $mmaMessages.markMessageRead(message.id).then(function() {
-                    console.log('MARKING MESSAGE AS READ');
                     message.read = 1;
-                    console.log(message);
                 });
             }
         });

--- a/www/addons/messages/controllers/discussions.js
+++ b/www/addons/messages/controllers/discussions.js
@@ -24,6 +24,7 @@ angular.module('mm.addons.messages')
 .controller('mmaMessagesDiscussionsCtrl', function($scope, $mmUtil, $mmaMessages, $rootScope, $mmEvents, $mmSite,
             mmCoreSplitViewLoad, mmaMessagesNewMessageEvent) {
     var newMessagesObserver,
+        currentUserId = $mmSite.getUserId(),
         siteId = $mmSite.getId(),
         discussions;
 
@@ -32,13 +33,31 @@ angular.module('mm.addons.messages')
     function fetchDiscussions() {
         return $mmaMessages.getDiscussions().then(function(discs) {
             discussions = discs;
-
             // Convert to an array for sorting.
             var array = [];
+            console.log(discussions);
+
             angular.forEach(discussions, function(v) {
+                v.unreadMsgs = 0;
+
+                console.log('Going THROUGH messages');
+                $mmaMessages.getDiscussion(v.message.user).then(function(messages) {
+                    console.log('PRINTING MESSAGES');
+                    console.log(messages);
+                    console.log('current user id is '+currentUserId);
+                    angular.forEach(messages, function(msg) {
+                        if (msg.read == 0 && msg.useridto == currentUserId) {
+                            console.log('found one unread message');
+                            v.unreadMsgs += 1;
+                        }
+                    });
+                });
+
                 array.push(v);
             });
             $scope.discussions = array;
+            console.log('PRINTING DISCUSSIONS AFTER')
+            console.log($scope.discussions);
         }, function(error) {
             if (typeof error === 'string') {
                 $mmUtil.showErrorModal(error);
@@ -55,6 +74,7 @@ angular.module('mm.addons.messages')
     }
 
     $scope.refresh = function() {
+        console.log('SCOPE  REFRESH');
         refreshData().finally(function() {
             $scope.$broadcast('scroll.refreshComplete');
         });
@@ -89,6 +109,7 @@ angular.module('mm.addons.messages')
 
     $scope.$on('$destroy', function() {
         if (newMessagesObserver && newMessagesObserver.off) {
+            console.log('DESTROY TRUE');
             newMessagesObserver.off();
         }
     });

--- a/www/addons/messages/controllers/discussions.js
+++ b/www/addons/messages/controllers/discussions.js
@@ -33,21 +33,14 @@ angular.module('mm.addons.messages')
     function fetchDiscussions() {
         return $mmaMessages.getDiscussions().then(function(discs) {
             discussions = discs;
+
             // Convert to an array for sorting.
             var array = [];
-            console.log(discussions);
-
             angular.forEach(discussions, function(v) {
                 v.unreadMsgs = 0;
-
-                console.log('Going THROUGH messages');
                 $mmaMessages.getDiscussion(v.message.user).then(function(messages) {
-                    console.log('PRINTING MESSAGES');
-                    console.log(messages);
-                    console.log('current user id is '+currentUserId);
                     angular.forEach(messages, function(msg) {
                         if (msg.read == 0 && msg.useridto == currentUserId) {
-                            console.log('found one unread message');
                             v.unreadMsgs += 1;
                         }
                     });
@@ -56,8 +49,6 @@ angular.module('mm.addons.messages')
                 array.push(v);
             });
             $scope.discussions = array;
-            console.log('PRINTING DISCUSSIONS AFTER')
-            console.log($scope.discussions);
         }, function(error) {
             if (typeof error === 'string') {
                 $mmUtil.showErrorModal(error);
@@ -74,7 +65,6 @@ angular.module('mm.addons.messages')
     }
 
     $scope.refresh = function() {
-        console.log('SCOPE  REFRESH');
         refreshData().finally(function() {
             $scope.$broadcast('scroll.refreshComplete');
         });
@@ -109,7 +99,6 @@ angular.module('mm.addons.messages')
 
     $scope.$on('$destroy', function() {
         if (newMessagesObserver && newMessagesObserver.off) {
-            console.log('DESTROY TRUE');
             newMessagesObserver.off();
         }
     });

--- a/www/addons/messages/controllers/discussions.js
+++ b/www/addons/messages/controllers/discussions.js
@@ -37,15 +37,9 @@ angular.module('mm.addons.messages')
             // Convert to an array for sorting.
             var array = [];
             angular.forEach(discussions, function(v) {
-                v.unreadMsgs = 0;
-                $mmaMessages.getDiscussion(v.message.user).then(function(messages) {
-                    angular.forEach(messages, function(msg) {
-                        if (msg.read == 0 && msg.useridto == currentUserId) {
-                            v.unreadMsgs += 1;
-                        }
-                    });
-                });
-
+                if (v.unread === undefined) {
+                    v.unread = 0;
+                }
                 array.push(v);
             });
             $scope.discussions = array;

--- a/www/addons/messages/scss/styles.scss
+++ b/www/addons/messages/scss/styles.scss
@@ -84,7 +84,7 @@ $mma-messages-date-badge: "stable" !default;
   }
 }
 
-.badge {
-  margin-top: 5%;
+.mma-messages-unread-badge {
+  margin-top: 6%;
   margin-right: -4%;
 }

--- a/www/addons/messages/scss/styles.scss
+++ b/www/addons/messages/scss/styles.scss
@@ -83,3 +83,8 @@ $mma-messages-date-badge: "stable" !default;
     left: initial;
   }
 }
+
+.badge {
+  margin-top: 5%;
+  margin-right: -4%;
+}

--- a/www/addons/messages/services/messages.js
+++ b/www/addons/messages/services/messages.js
@@ -442,16 +442,22 @@ angular.module('mm.addons.messages')
         }
     };
 
-    self.markMessageRead = function(message) {
+    /**
+     * Mark message as read.
+     *
+     * @module mm.addons.messages
+     * @ngdoc method
+     * @param messageId   ID of message to mark as read
+     * @returns {Promise} Promise resolved with boolean marking success or not.
+     */
+    self.markMessageRead = function(messageId) {
         var params = {
-            'messageid': message,
+            'messageid': messageId,
             'timeread': Math.floor(Date.now()/1000)
         };
         var preSets = {
             typeExpected: 'boolean'
         };
-        console.log('Parameters of mark_message_read WS call are: ');
-        console.log(params);
         return $mmSite.write('core_message_mark_message_read', params);
 
     };

--- a/www/addons/messages/services/messages.js
+++ b/www/addons/messages/services/messages.js
@@ -442,6 +442,20 @@ angular.module('mm.addons.messages')
         }
     };
 
+    self.markMessageRead = function(message) {
+        var params = {
+            'messageid': message,
+            'timeread': Math.floor(Date.now()/1000)
+        };
+        var preSets = {
+            typeExpected: 'boolean'
+        };
+        console.log('Parameters of mark_message_read WS call are: ');
+        console.log(params);
+        return $mmSite.write('core_message_mark_message_read', params);
+
+    };
+
     /**
      * Get user images for all the discussions that don't have one already.
      *

--- a/www/addons/messages/templates/discussions.html
+++ b/www/addons/messages/templates/discussions.html
@@ -9,7 +9,7 @@
                     <img src="img/user-avatar.png" alt="{{ 'mm.core.pictureof' | translate:{$a: disc.fullname} }}" role="presentation" ng-if="!disc.profileimageurl">
 
                     <span class="item-note" ng-if="disc.message.timecreated > 0">{{disc.message.timecreated / 1000 | mmDateDayOrTime}}</span>
-                    <i class="mma-messages-unread-badge badge badge-assertive">{{disc.unreadMsgs}}</i>
+                    <i class="mma-messages-unread-badge badge badge-assertive">{{disc.unread}}</i>
                     <p class="item-heading">{{disc.fullname}}</p>
                     <p><mm-format-text watch="true" clean="true" singleline="true">{{disc.message.message | mmaMessagesFormat}}</mm-format-text></p>
                 </a>

--- a/www/addons/messages/templates/discussions.html
+++ b/www/addons/messages/templates/discussions.html
@@ -9,7 +9,7 @@
                     <img src="img/user-avatar.png" alt="{{ 'mm.core.pictureof' | translate:{$a: disc.fullname} }}" role="presentation" ng-if="!disc.profileimageurl">
 
                     <span class="item-note" ng-if="disc.message.timecreated > 0">{{disc.message.timecreated / 1000 | mmDateDayOrTime}}</span>
-                    <i class="badge badge-assertive">{{disc.unreadMsgs}}</i>
+                    <i class="mma-messages-unread-badge badge badge-assertive">{{disc.unreadMsgs}}</i>
                     <p class="item-heading">{{disc.fullname}}</p>
                     <p><mm-format-text watch="true" clean="true" singleline="true">{{disc.message.message | mmaMessagesFormat}}</mm-format-text></p>
                 </a>

--- a/www/addons/messages/templates/discussions.html
+++ b/www/addons/messages/templates/discussions.html
@@ -9,6 +9,7 @@
                     <img src="img/user-avatar.png" alt="{{ 'mm.core.pictureof' | translate:{$a: disc.fullname} }}" role="presentation" ng-if="!disc.profileimageurl">
 
                     <span class="item-note" ng-if="disc.message.timecreated > 0">{{disc.message.timecreated / 1000 | mmDateDayOrTime}}</span>
+                    <i class="badge badge-assertive">{{disc.unreadMsgs}}</i>
                     <p class="item-heading">{{disc.fullname}}</p>
                     <p><mm-format-text watch="true" clean="true" singleline="true">{{disc.message.message | mmaMessagesFormat}}</mm-format-text></p>
                 </a>


### PR DESCRIPTION
Note that the count does not update in the discussion list after opening the discussion. The user has to pull down to refresh to get the updated count. At least this is a start for the feature.

Also note that it does one "mark as read" request per message. Maybe it would be better to use "mark all as read"? Like here: https://github.com/moodlehq/moodlemobile2/pull/729/files#diff-5ebdfd4a7501ca47e450e00dd02b7cf6R1104