### PR TITLE
MOBILE-2103 splitview: Clone state params object in split view states

### DIFF
--- a/www/addons/mod/feedback/controllers/respondents.js
+++ b/www/addons/mod/feedback/controllers/respondents.js
@@ -23,7 +23,7 @@ angular.module('mm.addons.mod_feedback')
  */
 .controller('mmaModFeedbackRespondentsCtrl', function($scope, $stateParams, $mmaModFeedback, $mmUtil, $q, $mmText, $translate,
         mmaModFeedbackComponent, $mmGroups, $mmaModFeedbackHelper, $ionicHistory) {
-    var module = $stateParams.module || {},
+    var module = $stateParams.module ? angular.copy($stateParams.module) : {},
         courseId = $stateParams.courseid,
         page = 0,
         feedback;

--- a/www/addons/mod/forum/controllers/discussions.js
+++ b/www/addons/mod/forum/controllers/discussions.js
@@ -25,7 +25,7 @@ angular.module('mm.addons.mod_forum')
             $mmEvents, $ionicScrollDelegate, $ionicPlatform, mmUserProfileState, mmaModForumNewDiscussionEvent, $mmSite, $translate,
             mmaModForumReplyDiscussionEvent, $mmText, mmaModForumComponent, $mmaModForumOffline, $mmaModForumSync, $mmCourseHelper,
             mmaModForumAutomSyncedEvent, mmaModForumManualSyncedEvent, $mmApp, mmCoreEventOnlineStatusChanged) {
-    var module = $stateParams.module || {},
+    var module = $stateParams.module ? angular.copy($stateParams.module) : {},
         courseid = $stateParams.courseid,
         forum,
         page = 0,

--- a/www/addons/mod/glossary/controllers/index.js
+++ b/www/addons/mod/glossary/controllers/index.js
@@ -26,7 +26,7 @@ angular.module('mm.addons.mod_glossary')
         $mmaModGlossaryOffline, $mmEvents, mmaModGlossaryAddEntryEvent, mmCoreEventOnlineStatusChanged, $mmApp, $mmSite,
         mmaModGlossaryAutomSyncedEvent, $mmaModGlossarySync, mmaModGlossaryShowAllCategories) {
 
-    var module = $stateParams.module || {},
+    var module = $stateParams.module ? angular.copy($stateParams.module) : {},
         courseId = $stateParams.courseid,
         glossary,
         noop = function(){},

--- a/www/addons/participants/controllers/list.js
+++ b/www/addons/participants/controllers/list.js
@@ -21,9 +21,8 @@ angular.module('mm.addons.participants')
  * @ngdoc controller
  * @name mmaParticipantsListCtrl
  */
-.controller('mmaParticipantsListCtrl', function($scope, $state, $stateParams, $mmUtil, $mmaParticipants, $ionicPlatform, $mmSite,
-            mmUserProfileState) {
-    var course = $stateParams.course,
+.controller('mmaParticipantsListCtrl', function($scope, $stateParams, $mmUtil, $mmaParticipants, $mmSite, mmUserProfileState) {
+    var course = angular.copy($stateParams.course),
         courseid = course.id;
 
     $scope.participants = [];

--- a/www/core/components/course/controllers/sections.js
+++ b/www/core/components/course/controllers/sections.js
@@ -27,7 +27,7 @@ angular.module('mm.core.course')
     var courseId = $stateParams.courseid,
         sectionId = $stateParams.sid,
         moduleId = $stateParams.moduleid,
-        course = $stateParams.course || false;
+        course = $stateParams.course ? angular.copy($stateParams.course) : false;
 
     $scope.courseId = courseId;
     $scope.sectionToLoad = 2; // Load "General" section by default.


### PR DESCRIPTION
If the objects are modified inside the controller, Ionic will open the left state again when loading the split view content.