### PR TITLE
MOBILE-2252 lti: Avoid cache when launching

### DIFF
--- a/www/addons/mod/lti/services/lti.js
+++ b/www/addons/mod/lti/services/lti.js
@@ -133,7 +133,11 @@ angular.module('mm.addons.mod_lti')
         var params = {
                 toolid: id
             },
+            // Try to avoid using cache since the "nonce" parameter is set to a timestamp.
             preSets = {
+                getFromCache: 0,
+                saveToCache: 1,
+                emergencyCache: 1,
                 cacheKey: getLtiLaunchDataCacheKey(id)
             };
 

--- a/www/addons/mod/lti/templates/index.html
+++ b/www/addons/mod/lti/templates/index.html
@@ -9,10 +9,7 @@
     </ion-nav-buttons>
     <ion-content padding="true" mm-state-class>
         <ion-refresher pulling-text="{{ 'mm.core.pulltorefresh' | translate }}" on-refresh="doRefresh()" ng-if="ltiLoaded"></ion-refresher>
-        <mm-loading hide-until="ltiLoaded">
-            <mm-course-mod-description watch="true" description="description" component="{{component}}" component-id="{{componentId}}"></mm-course-mod-description>
-            <a ng-if="isValidUrl" ng-click="launch()" class="button button-block icon-left ion-link">{{ 'mma.mod_lti.launchactivity' | translate }}</a>
-            <div class="mm-info-card" ng-if="!isValidUrl">{{ 'mma.mod_lti.errorinvalidlaunchurl' | translate }}</div>
-        </mm-loading>
+        <mm-course-mod-description watch="true" description="description" component="{{component}}" component-id="{{componentId}}"></mm-course-mod-description>
+        <a ng-click="launch()" class="button button-block icon-left ion-link">{{ 'mma.mod_lti.launchactivity' | translate }}</a>
     </ion-content>
 </ion-view>


### PR DESCRIPTION
We use now only the emergencyCache to avoid repeat values like the
oauth_nonce (that it is usually a timestamp and should be unique
between requests).
Refresh options could be removed, but I think is ok to keep it for
debugging.