### PR TITLE
MOBILE-2721 Keep existing displayname if not set

### DIFF
--- a/src/core/course/pages/section/section.ts
+++ b/src/core/course/pages/section/section.ts
@@ -171,6 +171,10 @@ export class CoreCourseSectionPage implements OnDestroy {
             // Error getting the course, probably guest access.
         }).then((course) => {
             if (course) {
+                if (this.course.id === course.id && this.course.hasOwnProperty('displayname')
+                        && !course.hasOwnProperty('displayname')) {
+                    course.displayname = this.course.displayname;
+                }
                 this.course = course;
             }
 


### PR DESCRIPTION
core_enrol_get_users_courses does not return displayname before MDL-63523,
which causes the page title to revert to fullname after the course
has fully loaded.