### PR TITLE
MOBILE-3140 Blocks: Make blocks work if displaydata not specified

### DIFF
--- a/src/core/siteplugins/providers/helper.ts
+++ b/src/core/siteplugins/providers/helper.ts
@@ -664,7 +664,8 @@ export class CoreSitePluginsHelperProvider {
 
         const uniqueName = this.sitePluginsProvider.getHandlerUniqueName(plugin, handlerName),
             blockName = (handlerSchema.moodlecomponent || plugin.component).replace('block_', ''),
-            prefixedTitle = this.getPrefixedString(plugin.addon, handlerSchema.displaydata.title || 'pluginname');
+            titleString = (handlerSchema.displaydata && handlerSchema.displaydata.title) ? handlerSchema.displaydata.title : 'pluginname',
+            prefixedTitle = this.getPrefixedString(plugin.addon, titleString);
 
         this.blockDelegate.registerHandler(
             new CoreSitePluginsBlockHandler(uniqueName, prefixedTitle, blockName, handlerSchema, initResult));


### PR DESCRIPTION
If displaydata is not specified in mobile.php for a block, it
did not work due to a JavaScript error.