### PR TITLE
MOBILE-3180 Site plugins: Plugin pages offline can break navigation

### DIFF
--- a/src/core/siteplugins/components/plugin-content/plugin-content.ts
+++ b/src/core/siteplugins/components/plugin-content/plugin-content.ts
@@ -107,6 +107,10 @@ export class CoreSitePluginsPluginContentComponent implements OnInit, DoCheck {
 
             this.onContentLoaded.emit(refresh);
         }).catch((error) => {
+            // Make it think it's loaded - otherwise it sticks on 'loading' and stops navigation working.
+            this.content = '<div></div>';
+            this.onContentLoaded.emit(refresh);
+
             this.domUtils.showErrorModalDefault(error, 'core.errorloadingcontent', true);
         }).finally(() => {
             this.dataLoaded = true;


### PR DESCRIPTION
For pages served via a site plugin, if the page has never been viewed
(there is no cached version) then if you try to view the page when
offline, the navigation broke because page loading never finished.

This change makes it finish page loading (with a blank page) if it
shows the error about failing to load it.