### PR TITLE
MOBILE-3213 core: Revert keyboard plugin to 2.1.3

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -160,7 +160,7 @@
     </plugin>
     <plugin name="cordova-plugin-globalization" spec="1.11.0" />
     <plugin name="cordova-plugin-inappbrowser" spec="3.1.0" />
-    <plugin name="cordova-plugin-ionic-keyboard" spec="2.2.0" />
+    <plugin name="cordova-plugin-ionic-keyboard" spec="2.1.3" />
     <plugin name="cordova-plugin-local-notification" spec="https://github.com/moodlemobile/cordova-plugin-local-notification.git#moodle" />
     <plugin name="cordova-plugin-media-capture" spec="3.0.3" />
     <plugin name="cordova-plugin-network-information" spec="2.0.2" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -3157,9 +3157,9 @@
       "integrity": "sha512-YqrZfYgbGTS20SFID0mrRxud312VH072QVlFonCAkPgtGg1Svy7lELOCNFd+KU7t4mVtZeTEjZPEeefvjaetwQ=="
     },
     "cordova-plugin-ionic-keyboard": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cordova-plugin-ionic-keyboard/-/cordova-plugin-ionic-keyboard-2.2.0.tgz",
-      "integrity": "sha512-yDUG+9ieKVRitq5mGlNxjaZh/MgEhFFIgTIPhqSbUaQ8UuZbawy5mhJAVClqY97q8/rcQtL6dCDa7x2sEtCLcA=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-ionic-keyboard/-/cordova-plugin-ionic-keyboard-2.1.3.tgz",
+      "integrity": "sha512-6ucQ6FdlLdBm8kJfFnzozmBTjru/0xekHP/dAhjoCZggkGRlgs8TsUJFkxa/bV+qi7Dlo50JjmpE4UMWAO+aOQ=="
     },
     "cordova-plugin-local-notification": {
       "version": "git+https://github.com/moodlemobile/cordova-plugin-local-notification.git#c7430c4f4f8b8c82d051aea49d87da0b4f6a8b1e",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "cordova-plugin-geolocation": "4.0.2",
     "cordova-plugin-globalization": "1.11.0",
     "cordova-plugin-inappbrowser": "3.1.0",
-    "cordova-plugin-ionic-keyboard": "2.2.0",
+    "cordova-plugin-ionic-keyboard": "2.1.3",
     "cordova-plugin-local-notification": "git+https://github.com/moodlemobile/cordova-plugin-local-notification.git#moodle",
     "cordova-plugin-media-capture": "3.0.3",
     "cordova-plugin-network-information": "2.0.2",


### PR DESCRIPTION
The 2.2.0 version causes the input text to be behind the keyboard when sending messages.