### PR TITLE
MOBILE-3833 core: Remove element on destroy

### DIFF
--- a/src/core/directives/collapsible-footer.ts
+++ b/src/core/directives/collapsible-footer.ts
@@ -254,6 +254,7 @@ export class CoreCollapsibleFooterDirective implements OnInit, OnDestroy {
             this.page.removeEventListener('ionViewDidEnter', this.pageDidEnterListener);
         }
 
+        this.element?.remove();
         this.resizeListener?.off();
         this.slotPromise?.cancel();
         this.viewportPromise?.cancel();


### PR DESCRIPTION
Angular usually removes elements, but in the collapsible-footer it needs to be done manually because it was moved to a different container