### PR TITLE
MOBILE-4084 folder: Restore access to inline folders

### DIFF
--- a/src/core/features/course/components/module-summary/module-summary.html
+++ b/src/core/features/course/components/module-summary/module-summary.html
@@ -24,8 +24,8 @@
                     </core-format-text>
                 </h1>
             </ion-label>
-            <ion-button fill="clear" *ngIf="displayOptions.displayOpenInBrowser" [href]="externalUrl" core-link [showBrowserWarning]="false"
-                [attr.aria-label]="'core.openinbrowser' | translate" slot="end">
+            <ion-button fill="clear" *ngIf="displayOptions.displayOpenInBrowser && externalUrl" [href]="externalUrl" core-link
+                [showBrowserWarning]="false" [attr.aria-label]="'core.openinbrowser' | translate" slot="end">
                 <ion-icon name="fas-external-link-alt" slot="icon-only" aria-hidden="true"></ion-icon>
             </ion-button>
         </ion-item>


### PR DESCRIPTION
Add temporary fix to restore access to inline folders.
Change module description to exclude inline folder data.