### PR TITLE
MOBILE-4173 behat: Limit embedded PDF test to 4.3+

### DIFF
--- a/src/core/tests/behat/open_files.feature
+++ b/src/core/tests/behat/open_files.feature
@@ -58,6 +58,7 @@ Feature: It opens files properly.
     And I press "Open" in the app
     Then I should find "This file may not work as expected on this device" in the app
 
+  @lms_from4.3
   Scenario: Open a PDF embedded using an iframe
     Given the following "activities" exist:
       | activity | idnumber | course | name                   | content                                                                                             |


### PR DESCRIPTION
This is because #wwwroot# isn't supported in older versions