### PR TITLE
MOBILE-4470 ios: Increase iOS min deployment target to 13.0

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -42,6 +42,7 @@
     <preference name="AndroidPersistentFileLocation" value="Compatibility" />
     <preference name="AndroidInsecureFileModeEnabled" value="true" />
     <preference name="CustomURLSchemePluginClearsAndroidIntent" value="true" />
+    <preference name="deployment-target" value="13.0" />
     <preference name="iosPersistentFileLocation" value="Compatibility" />
     <preference name="iosScheme" value="moodleappfs" />
     <preference name="WKWebViewOnly" value="true" />


### PR DESCRIPTION
The 4.4 app doesn't work in iOS 11 and 12, and Ionic doesn't test the framework in iOS 11-13. So we decided to increase the deployment target to 13.0