### PR TITLE
MOBILE-4672 mathjax: Fix some equations not displayed in quiz

### DIFF
--- a/src/addons/filter/mathjaxloader/services/handlers/mathjaxloader.ts
+++ b/src/addons/filter/mathjaxloader/services/handlers/mathjaxloader.ts
@@ -24,6 +24,7 @@ import { CoreEvents } from '@singletons/events';
 import { CoreSite } from '@classes/sites/site';
 import { makeSingleton } from '@singletons';
 import { CoreWait } from '@singletons/wait';
+import { CoreDom } from '@singletons/dom';
 
 /**
  * Handler to support the MathJax filter.
@@ -176,6 +177,10 @@ export class AddonFilterMathJaxLoaderHandlerService extends CoreFilterDefaultHan
         siteId?: string, // eslint-disable-line @typescript-eslint/no-unused-vars
     ): Promise<void> {
         await this.waitForReady();
+
+        // Make sure the element is in DOM, otherwise some equations don't work.
+        // Automatically timeout the promise after a certain time, we don't want to wait forever.
+        await CoreUtils.ignoreErrors(CoreUtils.timeoutPromise(CoreDom.waitToBeInDOM(container), 15000));
 
         await this.window.M!.filter_mathjaxloader!.typeset(container);
     }


### PR DESCRIPTION
For some reason, if we tell MathJax to render an equation for an element that isn't in the DOM, for some equations it fails and displays the error message (which is an exclamation mark). If we want to be sure the equation is rendered properly we need to wait for the element to be in the DOM.