### PR TITLE
MOBILE-4716 core: Fix regressions caused by boolean initializers

### DIFF
--- a/src/core/components/sites-list/sites-list.ts
+++ b/src/core/components/sites-list/sites-list.ts
@@ -45,7 +45,7 @@ export class CoreSitesListComponent<T extends CoreSiteBasicInfo> {
 
     @Input({ required: true }) accountsList!: CoreAccountsList<T>;
     @Input({ transform: toBoolean }) sitesClickable = false; // Whether the sites are clickable.
-    @Input({ transform: toBoolean }) currentSiteClickable = false; // If set, specify a different clickable value for current site.
+    @Input({ transform: toBoolean }) currentSiteClickable?: boolean; // If set, set a different clickable value for current site.
     @Output() onSiteClicked = new EventEmitter<T>();
 
     @ContentChild('siteItem') siteItemTemplate?: TemplateRef<{site: T; isCurrentSite: boolean}>;

--- a/src/core/directives/format-text.ts
+++ b/src/core/directives/format-text.ts
@@ -91,7 +91,7 @@ export class CoreFormatTextDirective implements OnChanges, OnDestroy, AsyncDirec
     @Input() courseId?: number; // Course ID the text belongs to. It can be used to improve performance with filters.
     @Input({ transform: toBoolean }) wsNotFiltered = false; // If true it means the WS didn't filter the text for some reason.
     @Input({ transform: toBoolean }) captureLinks = true; // Whether links should tried to be opened inside the app.
-    @Input({ transform: toBoolean }) openLinksInApp = false; // Whether links should be opened in InAppBrowser.
+    @Input({ transform: toBoolean }) openLinksInApp?: boolean; // Whether links should be opened in InAppBrowser.
     @Input({ transform: toBoolean }) disabled = false; // If disabled, autoplay elements will be disabled.
 
     /**

--- a/src/core/directives/link.ts
+++ b/src/core/directives/link.ts
@@ -39,7 +39,11 @@ export class CoreLinkDirective implements OnInit {
 
     @Input() href?: string | SafeUrl; // Link URL.
     @Input({ transform: toBoolean }) capture = false; // If the link needs to be captured by the app.
-    @Input({ transform: toBoolean }) inApp = false; // True to open in embedded browser, false to open in system browser.
+    /**
+     * True to force open in embedded browser, false to force open in system browser, undefined to determine it based on
+     * forceOpenLinksIn setting and data-open-in attribute.
+     */
+    @Input({ transform: toBoolean }) inApp?: boolean;
     @Input({ transform: toBoolean }) autoLogin = true; // Whether to try to use auto-login.
     @Input({ transform: toBoolean }) showBrowserWarning = true; // Whether to show a warning before opening browser.
 

--- a/src/core/features/course/components/course-format/course-format.ts
+++ b/src/core/features/course/components/course-format/course-format.ts
@@ -98,7 +98,7 @@ export class CoreCourseFormatComponent implements OnInit, OnChanges, OnDestroy {
     @Input() initialSectionNumber?: number; // The section to load first (by number).
     @Input() initialBlockInstanceId?: number; // The instance to focus.
     @Input() moduleId?: number; // The module ID to scroll to. Must be inside the initial selected section.
-    @Input({ transform: toBoolean }) isGuest = false; // If user is accessing using an ACCESS_GUEST enrolment method.
+    @Input({ transform: toBoolean }) isGuest?: boolean; // If user is accessing using an ACCESS_GUEST enrolment method.
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     @ViewChildren(CoreDynamicComponent) dynamicComponents?: QueryList<CoreDynamicComponent<any>>;

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -58,7 +58,7 @@ export interface EnvironmentConfig {
     appstores: Record<string, string>;
     displayqroncredentialscreen?: boolean;
     displayqronsitescreen?: boolean;
-    forceOpenLinksIn: 'app' | 'browser';
+    forceOpenLinksIn?: 'app' | 'browser';
     iOSDefaultOpenFileAction?: OpenFileAction;
     customMainMenuItems?: CoreMainMenuLocalizedCustomItem[];
     feedbackFormUrl?: string | false;


### PR DESCRIPTION
Some inputs were meant to allow undefined values, and adding an initializer broke that.