### PR TITLE
MOBILE-4653 core: Fix issue with lazy handlers

### DIFF
--- a/src/core/utils/async-instance.ts
+++ b/src/core/utils/async-instance.ts
@@ -210,20 +210,20 @@ export function asyncInstance<TLazyInstance extends TEagerInstance, TEagerInstan
                 return Reflect.get(target, property, receiver);
             }
 
-            if (wrapper.instance) {
-                const value = Reflect.get(wrapper.instance, property, receiver);
-
-                return isMethod(value)
-                    ? async (...args: unknown[]) => value.call(wrapper.instance, ...args)
-                    : value;
-            }
-
             if (
                 wrapper.eagerInstance &&
                 property in wrapper.eagerInstance &&
                 !wrapper.lazyOverrides?.includes(property)
             ) {
                 return Reflect.get(wrapper.eagerInstance, property, receiver);
+            }
+
+            if (wrapper.instance) {
+                const value = Reflect.get(wrapper.instance, property, receiver);
+
+                return isMethod(value)
+                    ? async (...args: unknown[]) => value.call(wrapper.instance, ...args)
+                    : value;
             }
 
             if (


### PR DESCRIPTION
After the async instance was used once, the app always used the async instance instead of the eager instance, causing problems with synchronous functions. For example after using a link handler to open a link, that link handler always used the async instance so the 'handles' function returned a Promise instead of a boolean. This made the app think that the link handler could open any link, opening the wrong page in some cases.