### PR TITLE
MOBILE-4653 data: Fix template rendering

### DIFF
--- a/src/addons/mod/data/tests/behat/links.feature
+++ b/src/addons/mod/data/tests/behat/links.feature
@@ -30,7 +30,7 @@ Feature: Users can manage entries in database activities
   @javascript
   Scenario: Create links in list template
     Given I set the following fields to these values:
-      | Repeated entry | <div class="colleague-entry-value mt-4"><span class="colleague-entry-value-title font-weight-bold">[[Email-Adresse#name]]</span><p><a href="mailto:[[Email-Adresse]]">[[Email-Adresse]]</a></p></div> |
+      | Repeated entry | <div class="colleague-entry-value mt-4"><span class="colleague-entry-value-title font-weight-bold">[[Email-Adresse#name]]</span><p><a href="mailto:[[Email-Adresse]]">Mail: [[Email-Adresse]]</a></p></div> |
     And I click on "Save" "button" in the "sticky-footer" "region"
 
     And I entered the data activity "Test database name" on course "Course 1" as "teacher1" in the app


### PR DESCRIPTION
An error was displayed when a field had no content. Also, only fields as the only child of elements were correctly rendered.