### PR TITLE
MOBILE-4974 bbb: Fix recording not opened if different group selected

### DIFF
--- a/src/addons/mod/bigbluebuttonbn/components/index/index.ts
+++ b/src/addons/mod/bigbluebuttonbn/components/index/index.ts
@@ -39,6 +39,7 @@ import { CoreToasts, ToastDuration } from '@services/overlays/toasts';
 import { CoreSharedModule } from '@/core/shared.module';
 import { CoreCourseModuleInfoComponent } from '@features/course/components/module-info/module-info';
 import { CoreCourseModuleNavigationComponent } from '@features/course/components/module-navigation/module-navigation';
+import { CoreUrl } from '@static/url';
 
 /**
  * Component that displays a Big Blue Button activity.
@@ -492,7 +493,12 @@ export class AddonModBBBIndexComponent extends CoreCourseModuleMainActivityCompo
         event.preventDefault();
         event.stopPropagation();
 
-        CoreSites.getCurrentSite()?.openInBrowserWithAutoLogin(playback.url);
+        let url = playback.url;
+        if (!url.match(/[&?]group=/)) {
+            url = CoreUrl.addParamsToUrl(url, { group: String(this.groupId()) });
+        }
+
+        CoreSites.getCurrentSite()?.openInBrowserWithAutoLogin(url);
     }
 
 }


### PR DESCRIPTION
If the user had already selected a group in the BBB activity in browser and the app tried to open a recording from a different group, an error was displayed: The recording was not found.