### PR TITLE
MOBILE-4974 assign: Fix filtering of submissions needing grading

### DIFF
--- a/src/addons/mod/assign/services/assign.ts
+++ b/src/addons/mod/assign/services/assign.ts
@@ -977,12 +977,12 @@ export class AddonModAssignProvider {
             isBlind: !!submission.blindid,
         });
 
-        if (!response.feedback || !response.feedback.gradeddate) {
+        if (!response.feedback?.grade?.timemodified) {
             // Not graded.
             return true;
         }
 
-        return response.feedback.gradeddate < submission.timemodified;
+        return response.feedback.grade.timemodified < submission.timemodified;
     }
 
     /**


### PR DESCRIPTION
LMS uses the assign grade date instead of the gradebook grade date, which is not available in anonymous assignments.