### PR TITLE
MOBILE-5048 config: Restrict allow-navigation

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -9,10 +9,7 @@
     <access launch-external="yes" origin="mailto:*" />
     <access launch-external="yes" origin="geo:*" />
     <allow-navigation href="moodleappfs:*" />
-    <allow-navigation href="cdvfile:*" />
-    <allow-navigation href="content:*" />
-    <allow-navigation href="data:*" />
-    <allow-navigation href="*" />
+    <allow-navigation href="http://localhost/*" />
     <allow-intent href="*" />
     <allow-intent href="tel:*" />
     <allow-intent href="sms:*" />


### PR DESCRIPTION
allow-navigation controls the URLs that can be loaded in the iframe itself, and only our app should be loaded in there. A wrong plugin could override the app with an external page, but that's not the expected behaviour.

http://localhost/* is allowed by the Ionic WebView, but it's also defined in our config to make it clearer that it's allowed.