### PR TITLE
MOBILE-5048 config: Revert restrict allow-navigation

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -9,7 +9,10 @@
     <access launch-external="yes" origin="mailto:*" />
     <access launch-external="yes" origin="geo:*" />
     <allow-navigation href="moodleappfs:*" />
-    <allow-navigation href="http://localhost/*" />
+    <allow-navigation href="cdvfile:*" />
+    <allow-navigation href="content:*" />
+    <allow-navigation href="data:*" />
+    <allow-navigation href="*" />
     <allow-intent href="*" />
     <allow-intent href="tel:*" />
     <allow-intent href="sms:*" />


### PR DESCRIPTION
This reverts commit f295142bfae3545c9f4f5e0e168e1c4174f358af.

The allow-navigation configs are still needed in iOS, otherwise iframes to URLs different than the app one don't work.